### PR TITLE
Set different envelopes for "resource" and "collection"

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -342,7 +342,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @param string $assocName
      *
-     * @return boolean
+     * @return boolean|null
      */
     public function isAssociationInverseSide($assocName)
     {
@@ -485,7 +485,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * @param $type
+     * @param string $type
      * @param array $element
      */
     public function setRoute($type, array $element)
@@ -520,7 +520,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * @param $type
+     * @param string $type
      * @return array
      */
     public function getEnvelopes($type)
@@ -533,7 +533,7 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * @param $type
+     * @param string $type
      * @param array $element
      */
     public function setEnvelopes($type, array $element)

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -522,15 +522,16 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
+     * @param $type
      * @return array
      */
     public function getEnvelopes($type)
     {
         if ($this->hasEnvelope($type)) {
-            return $this->envelopes[$type];
+            return is_array($this->envelopes[$type]) ? $this->envelopes[$type] : array($this->envelopes[$type]);
         }
 
-        return null;
+        return array();
     }
 
     /**

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -485,15 +485,13 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
-     * @param array $routes
+     * @param $type
+     * @param array $element
      */
-    public function setRoutes(array $routes)
+    public function setRoute($type, array $element)
     {
-        if (isset($routes['resource'])) {
-            $this->routes['resource'] = $routes['resource'];
-        }
-        if (isset($routes['collection'])) {
-            $this->routes['collection'] = $routes['collection'];
+        if (isset($element['route'])) {
+            $this->routes[$type] = $element['route'];
         }
     }
 
@@ -528,22 +526,20 @@ class ClassMetadata implements ClassMetadataInterface
     public function getEnvelopes($type)
     {
         if ($this->hasEnvelope($type)) {
-            return is_array($this->envelopes[$type]) ? $this->envelopes[$type] : array($this->envelopes[$type]);
+            return $this->envelopes[$type];
         }
 
         return array();
     }
 
     /**
-     * @param array $envelopes
+     * @param $type
+     * @param array $element
      */
-    public function setEnvelopes(array $envelopes)
+    public function setEnvelopes($type, array $element)
     {
-        if (isset($envelopes['resource'])) {
-            $this->envelopes['resource'] = $envelopes['resource'];
-        }
-        if (isset($envelopes['collection'])) {
-            $this->envelopes['collection'] = $envelopes['collection'];
+        if (isset($element['envelopes'])) {
+            $this->envelopes[$type] = $element['envelopes'];
         }
     }
 

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -524,9 +524,13 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * @return array
      */
-    public function getEnvelopes()
+    public function getEnvelopes($type)
     {
-        return $this->envelopes;
+        if ($this->hasEnvelope($type)) {
+            return $this->envelopes[$type];
+        }
+
+        return null;
     }
 
     /**
@@ -534,7 +538,22 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function setEnvelopes(array $envelopes)
     {
-        $this->envelopes = $envelopes;
+        if (isset($envelopes['resource'])) {
+            $this->envelopes['resource'] = $envelopes['resource'];
+        }
+        if (isset($envelopes['collection'])) {
+            $this->envelopes['collection'] = $envelopes['collection'];
+        }
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    public function hasEnvelope($type)
+    {
+        return isset($this->envelopes[$type]);
     }
 
     /**

--- a/src/Mapping/Driver/YamlDriver.php
+++ b/src/Mapping/Driver/YamlDriver.php
@@ -37,12 +37,14 @@ class YamlDriver extends FileDriver
             $metadata->setFormat($element['format']);
         }
 
-        if (isset($element['envelopes'])) {
-            $metadata->setEnvelopes($element['envelopes']);
+        if (isset($element['resource'])) {
+            $metadata->setRoute('resource', $element['resource']);
+            $metadata->setEnvelopes('resource', $element['resource']);
         }
 
-        if (isset($element['routes'])) {
-            $metadata->setRoutes($element['routes']);
+        if (isset($element['collection'])) {
+            $metadata->setRoute('collection', $element['collection']);
+            $metadata->setEnvelopes('collection', $element['collection']);
         }
 
         if (isset($element['identifiers'])) {

--- a/src/Persister/BasicEntityPersister.php
+++ b/src/Persister/BasicEntityPersister.php
@@ -56,10 +56,11 @@ class BasicEntityPersister implements EntityPersister
      *
      * @param array       $criteria The criteria by which to load the entity.
      * @param object|null $entity   The entity to load the data into. If not specified, a new entity is created.
+     * @param string      $type     Entity type, either 'resource' or 'collection'
      *
      * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
      */
-    public function load(array $criteria, $entity = null)
+    public function load(array $criteria, $entity = null, $type = 'collection')
     {
         $uri     = $this->getUri($criteria);
         $request = $this->connection->createRequest('GET', $uri);
@@ -74,7 +75,7 @@ class BasicEntityPersister implements EntityPersister
             }
         }
 
-        $entities = $this->serializer->deserialize($response->getBody(true));
+        $entities = $this->serializer->deserialize($response->getBody(true), $type);
 
         return $entities ? $entities[0] : null;
     }
@@ -89,7 +90,7 @@ class BasicEntityPersister implements EntityPersister
      */
     public function loadById(array $identifier, $entity = null)
     {
-        return $this->load($identifier, $entity);
+        return $this->load($identifier, $entity, 'resource');
     }
 
     /**
@@ -122,4 +123,5 @@ class BasicEntityPersister implements EntityPersister
     {
         return $this->uriBuilder->createUri($criteria);
     }
+
 }

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -45,13 +45,14 @@ class Serializer
      * Decodes the serialized data, and then hydrates the entities.
      *
      * @param string $data
+     * @param string $type Entity type, either 'resource' or 'collection'
      *
      * @return array
      */
-    public function deserialize($data)
+    public function deserialize($data, $type = 'collection')
     {
         $data     = $this->decode($data);
-        $elements = $this->unwrap($data);
+        $elements = $this->unwrap($data, $type);
 
         $entities = array();
 
@@ -156,12 +157,13 @@ class Serializer
      * Unwraps the data from containers
      *
      * @param array $data
+     * @param string $type Entity type, either 'resource' or 'collection'
      *
      * @return array
      */
-    private function unwrap(array $data)
+    private function unwrap(array $data, $type = 'collection')
     {
-        $containers = $this->classMetadata->getEnvelopes();
+        $containers = $this->classMetadata->getEnvelopes($type);
 
         foreach ($containers as $container) {
             $data = $data[$container];

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -53,6 +53,7 @@ class Serializer
     {
         $data     = $this->decode($data);
         $elements = $this->unwrap($data, $type);
+        $elements = ($type == 'collection') ? $elements : array($elements);
 
         $entities = array();
 
@@ -166,9 +167,10 @@ class Serializer
         $containers = $this->classMetadata->getEnvelopes($type);
 
         foreach ($containers as $container) {
-            $data = $data[$container];
+            if (isset($data[$container])) {
+                $data = $data[$container];
+            }
         }
-
         return $data;
     }
 }

--- a/tests/Fixtures/config/RAPL.Tests.Fixtures.Entities.Book.rapl.yml
+++ b/tests/Fixtures/config/RAPL.Tests.Fixtures.Entities.Book.rapl.yml
@@ -1,15 +1,15 @@
 RAPL\Tests\Fixtures\Entities\Book:
     format: json
 
-    routes:
-        resource: books/{id}
-        collection: books
-
-    envelopes:
-        resource:
+    resource:
+        route: books/{id}
+        envelopes:
             - results
             - 0
-        collection: results
+    collection:
+        route: books
+        envelopes:
+            - results
 
     identifiers:
         id:

--- a/tests/Fixtures/config/RAPL.Tests.Fixtures.Entities.Book.rapl.yml
+++ b/tests/Fixtures/config/RAPL.Tests.Fixtures.Entities.Book.rapl.yml
@@ -8,8 +8,8 @@ RAPL\Tests\Fixtures\Entities\Book:
     envelopes:
         resource:
             - results
-        collection:
-            - results
+            - 0
+        collection: results
 
     identifiers:
         id:

--- a/tests/Fixtures/config/RAPL.Tests.Fixtures.Entities.Book.rapl.yml
+++ b/tests/Fixtures/config/RAPL.Tests.Fixtures.Entities.Book.rapl.yml
@@ -6,7 +6,10 @@ RAPL\Tests\Fixtures\Entities\Book:
         collection: books
 
     envelopes:
-        - results
+        resource:
+            - results
+        collection:
+            - results
 
     identifiers:
         id:

--- a/tests/Unit/Mapping/ClassMetadataTest.php
+++ b/tests/Unit/Mapping/ClassMetadataTest.php
@@ -260,34 +260,48 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($metadata->getRoute('resource'));
 
-        $routes = array(
-            'resource'   => 'foo/{id}.xml',
-            'collection' => 'foos.xml'
+        $element = array(
+          'resource' => array(
+            'route' => 'books/{id}',
+            'envelopes' => array('results', 0),
+          ),
+          'collection' => array(
+            'route' => 'books',
+            'envelopes' => array('results'),
+          ),
         );
 
-        $metadata->setRoutes($routes);
+        $metadata->setRoute('resource', $element['resource']);
+        $metadata->setRoute('collection', $element['collection']);
 
         $this->assertTrue($metadata->hasRoute('resource'));
         $this->assertTrue($metadata->hasRoute('collection'));
 
         $actual = $metadata->getRoute('collection');
 
-        $this->assertSame('foos.xml', $actual);
+        $this->assertSame('books', $actual);
     }
 
     public function testSetGetEnvelopes()
     {
         $metadata = $this->getClassMetadata();
 
-        $envelopes = array(
-          'resource' => array('foo'),
-          'collection' => array('bar'),
+        $element = array(
+          'resource' => array(
+            'route' => 'books/{id}',
+            'envelopes' => array('results', 0),
+          ),
+          'collection' => array(
+            'route' => 'books',
+            'envelopes' => array('results'),
+          ),
         );
 
-        $metadata->setEnvelopes($envelopes);
+        $metadata->setEnvelopes('resource', $element['resource']);
+        $metadata->setEnvelopes('collection', $element['collection']);
 
-        $this->assertSame($envelopes['resource'], $metadata->getEnvelopes('resource'));
-        $this->assertSame($envelopes['collection'], $metadata->getEnvelopes('collection'));
+        $this->assertSame($element['resource']['envelopes'], $metadata->getEnvelopes('resource'));
+        $this->assertSame($element['collection']['envelopes'], $metadata->getEnvelopes('collection'));
     }
 
     public function testSetFieldValue()

--- a/tests/Unit/Mapping/ClassMetadataTest.php
+++ b/tests/Unit/Mapping/ClassMetadataTest.php
@@ -279,13 +279,15 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $metadata = $this->getClassMetadata();
 
-        $envelopes = array('foo', 'bar');
+        $envelopes = array(
+          'resource' => array('foo'),
+          'collection' => array('bar'),
+        );
 
         $metadata->setEnvelopes($envelopes);
 
-        $actual = $metadata->getEnvelopes();
-
-        $this->assertSame($envelopes, $actual);
+        $this->assertSame($envelopes['resource'], $metadata->getEnvelopes('resource'));
+        $this->assertSame($envelopes['collection'], $metadata->getEnvelopes('collection'));
     }
 
     public function testSetFieldValue()

--- a/tests/Unit/Mapping/Driver/YamlDriverTest.php
+++ b/tests/Unit/Mapping/Driver/YamlDriverTest.php
@@ -3,6 +3,7 @@
 namespace RAPL\Tests\Unit\Mapping\Driver;
 
 use RAPL\RAPL\Mapping\Driver\YamlDriver;
+use Symfony\Component\Yaml\Yaml;
 
 class YamlDriverTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,8 +16,23 @@ class YamlDriverTest extends \PHPUnit_Framework_TestCase
 
         $metadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
         $metadata->shouldReceive('setFormat')->withArgs(array('json'))->once();
-        $metadata->shouldReceive('setRoutes')->withArgs(array(array('resource' => 'books/{id}', 'collection' => 'books')))->once();
-        $metadata->shouldReceive('setEnvelopes')->withArgs(array(array('resource' => array('results', 0), 'collection' => 'results')))->once();
+
+        $element = array(
+            'resource' => array(
+                'route' => 'books/{id}',
+                'envelopes' => array('results', 0),
+            ),
+            'collection' => array(
+                'route' => 'books',
+                'envelopes' => array('results'),
+            ),
+        );
+        $metadata->shouldReceive('setRoute')->withArgs(array('resource', $element['resource']))->once();
+        $metadata->shouldReceive('setEnvelopes')->withArgs(array('resource', $element['resource']))->once();
+
+        $metadata->shouldReceive('setRoute')->withArgs(array('collection', $element['collection']))->once();
+        $metadata->shouldReceive('setEnvelopes')->withArgs(array('collection', $element['collection']))->once();
+
 
         $metadata->shouldReceive('mapField')->withArgs(
             array(

--- a/tests/Unit/Mapping/Driver/YamlDriverTest.php
+++ b/tests/Unit/Mapping/Driver/YamlDriverTest.php
@@ -16,7 +16,7 @@ class YamlDriverTest extends \PHPUnit_Framework_TestCase
         $metadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
         $metadata->shouldReceive('setFormat')->withArgs(array('json'))->once();
         $metadata->shouldReceive('setRoutes')->withArgs(array(array('resource' => 'books/{id}', 'collection' => 'books')))->once();
-        $metadata->shouldReceive('setEnvelopes')->withArgs(array(array('results')))->once();
+        $metadata->shouldReceive('setEnvelopes')->withArgs(array(array('resource' => array('results'), 'collection' => array('results'))))->once();
 
         $metadata->shouldReceive('mapField')->withArgs(
             array(

--- a/tests/Unit/Mapping/Driver/YamlDriverTest.php
+++ b/tests/Unit/Mapping/Driver/YamlDriverTest.php
@@ -16,7 +16,7 @@ class YamlDriverTest extends \PHPUnit_Framework_TestCase
         $metadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
         $metadata->shouldReceive('setFormat')->withArgs(array('json'))->once();
         $metadata->shouldReceive('setRoutes')->withArgs(array(array('resource' => 'books/{id}', 'collection' => 'books')))->once();
-        $metadata->shouldReceive('setEnvelopes')->withArgs(array(array('resource' => array('results'), 'collection' => array('results'))))->once();
+        $metadata->shouldReceive('setEnvelopes')->withArgs(array(array('resource' => array('results', 0), 'collection' => 'results')))->once();
 
         $metadata->shouldReceive('mapField')->withArgs(
             array(

--- a/tests/Unit/Serializer/SerializerTest.php
+++ b/tests/Unit/Serializer/SerializerTest.php
@@ -23,7 +23,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $classMetadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
         $classMetadata->shouldReceive('getName')->andReturn($entityName);
         $classMetadata->shouldReceive('getFormat')->andReturn('json');
-        $classMetadata->shouldReceive('getEnvelopes')->andReturn(array());
+        $classMetadata->shouldReceive('getEnvelopes')->andReturn(array('results'));
 
         $classMetadata->shouldReceive('hasField')->andReturn('true');
 
@@ -82,7 +82,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
         $serializer = new Serializer($manager, $classMetadata);
 
-        $data = '[{
+        $data = '{"results":[{
             "string": "Foo Bar",
             "integer": 5,
             "boolean": false,
@@ -91,7 +91,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
                 "foo": "Bar"
             },
             "unknown": "adsf"
-        }]';
+        }]}';
 
 
         $actual = $serializer->deserialize($data);


### PR DESCRIPTION
### Problem/motivation
Currently envelopes can be set globally, regardless if an entity route refers to a "resource" or a "collection". Some REST services could use a different envelope value per type of operation, for example a collection could have:

```
GET https://api.tradegecko.com/products/
 {
      "products": [
          {
              "id": 2,
              "name": "BUTTERFLY TEE",
              "description": "An awesome product",
              "created_at": "2013-04-18T04:40:00Z",
```

While a resource could have:

```
GET https://api.tradegecko.com/products/{PRODUCT_ID}        
 {
      "product": {
          "created_at": "2013-04-18T04:40:00Z",
          "description": "An awesome product",
          "id": 2,
          "image_url": null,
          "name": "BUTTERFLY TEE",
```

(The above example is taken from http://developer.tradegecko.com/api/product/)

### Proposed solution
Change entity configuration layout in order to be able to specify envelopes per route type. 

```
RAPL\Tests\Fixtures\Entities\Book:
    format: json

    resource:
        route: books/{id}
        envelopes:
            - results
            - 0
    collection:
        route: books
        envelopes:
            - results
```

**NOTE**: Even though the current pull request does provide a working solution (including basic test coverage) its main aim is to get the conversation started on this particular issue.