### PR TITLE
Drop PHP 5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ It implements the same interfaces, but allows you to store and retrieve entities
 [![Coverage Status](https://img.shields.io/coveralls/rapl/rapl.svg?style=flat)](https://coveralls.io/r/rapl/rapl)
 [![Code Quality](https://img.shields.io/scrutinizer/g/rapl/rapl.svg?style=flat)](https://scrutinizer-ci.com/g/rapl/rapl/)
 
+## Requirements
+
+RAPL requires PHP 5.4 or higher.
+
 ## Installation
 
 RAPL can be installed using [Composer](https://getcomposer.org/):

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4.0",
         "doctrine/common": "~2.4",
         "guzzle/guzzle": "~3.9",
         "symfony/serializer": "~2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6ecbfb2ff4c964f1d56f4022aceab1c1",
+    "hash": "793ba638e2e1513bb4b37ad371716b86",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1771,6 +1771,9 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
-    "platform": [],
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.4.0"
+    },
     "platform-dev": []
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -11,7 +11,7 @@ class Configuration
     /**
      * @var array
      */
-    private $entityNamespaces = array();
+    private $entityNamespaces = [];
 
     /**
      * @var MappingDriver|null

--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -41,7 +41,7 @@ class EntityRepository implements ObjectRepository
             $idFields = $this->classMetadata->getIdentifierFieldNames();
             $idField  = reset($idFields);
 
-            $id = array($idField => $id);
+            $id = [$idField => $id];
         }
 
         return $this->persister->loadById($id);
@@ -54,7 +54,7 @@ class EntityRepository implements ObjectRepository
      */
     public function findAll()
     {
-        return $this->findBy(array());
+        return $this->findBy([]);
     }
 
     /**
@@ -73,7 +73,7 @@ class EntityRepository implements ObjectRepository
      *
      * @throws \UnexpectedValueException
      */
-    public function findBy(array $criteria, array $orderBy = array(), $limit = null, $offset = null)
+    public function findBy(array $criteria, array $orderBy = [], $limit = null, $offset = null)
     {
         return $this->persister->loadAll($criteria, $orderBy, $limit, $offset);
     }

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -33,7 +33,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * @var array
      */
-    private $fieldMappings = array();
+    private $fieldMappings = [];
 
     /**
      * An array of field names, used to look up field names from serialized names.
@@ -41,7 +41,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var array
      */
-    private $fieldNames = array();
+    private $fieldNames = [];
 
     /**
      * The association mappings of the class.
@@ -49,14 +49,14 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var array
      */
-    private $associationMappings = array();
+    private $associationMappings = [];
 
     /**
      * The field names of all fields that are part of the identifier / primary key.
      *
      * @var array
      */
-    private $identifierFieldNames = array();
+    private $identifierFieldNames = [];
 
     /**
      * The ReflectionClass instance of the mapped class.
@@ -70,7 +70,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * @var \ReflectionProperty[]
      */
-    private $reflFields = array();
+    private $reflFields = [];
 
     /**
      * The prototype from which new instances of the mapped class are created.
@@ -87,7 +87,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * @var Route[][]
      */
-    private $routes = array();
+    private $routes = [];
 
     /**
      * @param string $className
@@ -382,7 +382,7 @@ class ClassMetadata implements ClassMetadataInterface
         $fieldName = $this->identifierFieldNames[0];
         $value     = $this->reflFields[$fieldName]->getValue($object);
 
-        return array($fieldName => $value);
+        return [$fieldName => $value];
     }
 
     /**

--- a/src/Mapping/Driver/YamlDriver.php
+++ b/src/Mapping/Driver/YamlDriver.php
@@ -42,13 +42,13 @@ class YamlDriver extends FileDriver
         if (isset($element['identifiers'])) {
             foreach ($element['identifiers'] as $fieldName => $fieldElement) {
                 $metadata->mapField(
-                    array(
+                    [
                         'fieldName'      => $fieldName,
                         'type'           => (isset($fieldElement['type'])) ? $fieldElement['type'] : null,
                         'serializedName' => (isset($fieldElement['serializedName'])) ?
                             (string) $fieldElement['serializedName'] : null,
                         'id'             => true,
-                    )
+                    ]
                 );
             }
         }
@@ -56,12 +56,12 @@ class YamlDriver extends FileDriver
         if (isset($element['fields'])) {
             foreach ($element['fields'] as $fieldName => $mapping) {
                 $metadata->mapField(
-                    array(
+                    [
                         'fieldName'      => $fieldName,
                         'type'           => (isset($mapping['type'])) ? $mapping['type'] : null,
                         'serializedName' => (isset($mapping['serializedName'])) ? (string) $mapping['serializedName'] :
                             null,
-                    )
+                    ]
                 );
             }
         }
@@ -69,12 +69,12 @@ class YamlDriver extends FileDriver
         if (isset($element['embedOne'])) {
             foreach ($element['embedOne'] as $fieldName => $embedElement) {
                 $metadata->mapEmbedOne(
-                    array(
+                    [
                         'targetEntity'   => (string) $embedElement['targetEntity'],
                         'fieldName'      => $fieldName,
                         'serializedName' => (isset($embedElement['serializedName'])) ?
                             (string) $embedElement['serializedName'] : null,
-                    )
+                    ]
                 );
             }
         }
@@ -86,10 +86,10 @@ class YamlDriver extends FileDriver
      */
     protected function setRoutes(ClassMetadata $metadata, array $element)
     {
-        foreach (array('resource', 'collection') as $type) {
+        foreach (['resource', 'collection'] as $type) {
             if (isset($element[$type]) && isset($element[$type]['route'])) {
                 $pattern   = $element[$type]['route'];
-                $envelopes = (isset($element[$type]['envelopes'])) ? $element[$type]['envelopes'] : array();
+                $envelopes = (isset($element[$type]['envelopes'])) ? $element[$type]['envelopes'] : [];
 
                 if ($type === 'resource') {
                     $returnsCollection = false;

--- a/src/Mapping/Route.php
+++ b/src/Mapping/Route.php
@@ -17,14 +17,14 @@ class Route
     /**
      * @var array
      */
-    private $envelopes = array();
+    private $envelopes = [];
 
     /**
      * @param string $pattern   The pattern used to build a URI
      * @param bool   $returnsCollection
      * @param array  $envelopes Envelopes in which the result data is wrapped
      */
-    public function __construct($pattern, $returnsCollection = true, $envelopes = array())
+    public function __construct($pattern, $returnsCollection = true, $envelopes = [])
     {
         $this->pattern           = $pattern;
         $this->returnsCollection = $returnsCollection;

--- a/src/Persister/BasicEntityPersister.php
+++ b/src/Persister/BasicEntityPersister.php
@@ -108,7 +108,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @return array
      */
-    public function loadAll(array $conditions = array(), array $orderBy = array(), $limit = null, $offset = null)
+    public function loadAll(array $conditions = [], array $orderBy = [], $limit = null, $offset = null)
     {
         $uri      = $this->getUri($conditions, $orderBy, $limit, $offset);
         $route    = $this->getRoute($conditions, $orderBy, $limit, $offset);
@@ -132,7 +132,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @return string
      */
-    private function getUri(array $conditions, array $orderBy = array(), $limit = null, $offset = null)
+    private function getUri(array $conditions, array $orderBy = [], $limit = null, $offset = null)
     {
         return $this->router->generate($this->classMetadata, $conditions, $orderBy, $limit, $offset);
     }
@@ -145,7 +145,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @return \RAPL\RAPL\Mapping\Route
      */
-    private function getRoute(array $conditions, array $orderBy = array(), $limit = null, $offset = null)
+    private function getRoute(array $conditions, array $orderBy = [], $limit = null, $offset = null)
     {
         return $this->router->getRoute($this->classMetadata, $conditions, $orderBy, $limit, $offset);
     }

--- a/src/Persister/EntityPersister.php
+++ b/src/Persister/EntityPersister.php
@@ -34,5 +34,5 @@ interface EntityPersister
      *
      * @return array
      */
-    public function loadAll(array $conditions = array(), array $orderBy = array(), $limit = null, $offset = null);
+    public function loadAll(array $conditions = [], array $orderBy = [], $limit = null, $offset = null);
 }

--- a/src/Routing/AbstractRouter.php
+++ b/src/Routing/AbstractRouter.php
@@ -20,8 +20,8 @@ abstract class AbstractRouter implements RouterInterface
      */
     public function generate(
         ClassMetadata $classMetadata,
-        array $conditions = array(),
-        array $orderBy = array(),
+        array $conditions = [],
+        array $orderBy = [],
         $limit = null,
         $offset = null
     ) {
@@ -79,8 +79,8 @@ abstract class AbstractRouter implements RouterInterface
      */
     public function getRoute(
         ClassMetadata $classMetadata,
-        array $conditions = array(),
-        array $orderBy = array(),
+        array $conditions = [],
+        array $orderBy = [],
         $limit = null,
         $offset = null
     ) {

--- a/src/Routing/Query.php
+++ b/src/Routing/Query.php
@@ -7,12 +7,12 @@ class Query
     /**
      * @var array
      */
-    protected $conditions = array();
+    protected $conditions = [];
 
     /**
      * @var array
      */
-    protected $orderBy = array();
+    protected $orderBy = [];
 
     /**
      * @var int|null
@@ -30,7 +30,7 @@ class Query
      * @param int|null $limit
      * @param int|null $offset
      */
-    public function __construct(array $conditions = array(), array $orderBy = array(), $limit = null, $offset = null)
+    public function __construct(array $conditions = [], array $orderBy = [], $limit = null, $offset = null)
     {
         $this->conditions = $conditions;
         $this->orderBy    = $orderBy;

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -43,8 +43,8 @@ class Serializer implements SerializerInterface
         $this->unitOfWork           = $unitOfWork;
         $this->classMetadataFactory = $metadataFactory;
 
-        $normalizers      = array(new GetSetMethodNormalizer());
-        $encoders         = array(new JsonEncoder());
+        $normalizers      = [new GetSetMethodNormalizer()];
+        $encoders         = [new JsonEncoder()];
         $this->serializer = new SymfonySerializer($normalizers, $encoders);
     }
 
@@ -57,16 +57,16 @@ class Serializer implements SerializerInterface
      *
      * @return array
      */
-    public function deserialize($data, $isCollection, array $envelopes = array())
+    public function deserialize($data, $isCollection, array $envelopes = [])
     {
         $data = $this->decode($data);
         $data = $this->unwrap($data, $envelopes);
 
         if (!$isCollection) {
-            $data = array($data);
+            $data = [$data];
         }
 
-        $hydratedEntities = array();
+        $hydratedEntities = [];
 
         foreach ($data as $entityData) {
             $entityData = $this->mapFromSerialized($entityData);
@@ -111,7 +111,7 @@ class Serializer implements SerializerInterface
             if (isset($data[$envelope])) {
                 $data = $data[$envelope];
             } else {
-                return array();
+                return [];
             }
         }
 
@@ -125,7 +125,7 @@ class Serializer implements SerializerInterface
      */
     private function mapFromSerialized(array $data)
     {
-        $mappedEntityData = array();
+        $mappedEntityData = [];
 
         foreach ($data as $serializedName => $value) {
             if ($this->classMetadata->hasField($this->classMetadata->getFieldName($serializedName))) {
@@ -133,7 +133,7 @@ class Serializer implements SerializerInterface
                 $fieldMapping = $this->classMetadata->getFieldMapping($fieldName);
 
                 if (isset($fieldMapping['association'])) {
-                    $embedded = array();
+                    $embedded = [];
 
                     $associationMetadata   = $this->classMetadataFactory->getMetadataFor($fieldMapping['targetEntity']);
                     $associationSerializer = new Serializer(

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -21,19 +21,19 @@ abstract class Type
     /**
      * @var array
      */
-    private static $typesMap = array(
+    private static $typesMap = [
         self::TYPE_ARRAY    => 'RAPL\RAPL\Types\ArrayType',
         self::TYPE_BOOLEAN  => 'RAPL\RAPL\Types\BooleanType',
         self::TYPE_DATETIME => 'RAPL\RAPL\Types\DateTimeType',
         self::TYPE_FLOAT    => 'RAPL\RAPL\Types\FloatType',
         self::TYPE_INTEGER  => 'RAPL\RAPL\Types\IntegerType',
         self::TYPE_STRING   => 'RAPL\RAPL\Types\StringType',
-    );
+    ];
 
     /**
      * @var Type[]
      */
-    private static $typeObjects = array();
+    private static $typeObjects = [];
 
     /**
      * Prevents instantiation and forces use of the factory method.

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -49,7 +49,7 @@ class UnitOfWork
      *
      * @var array
      */
-    private $persisters = array();
+    private $persisters = [];
 
     /**
      * The identity map that holds references to all managed entities that have
@@ -59,7 +59,7 @@ class UnitOfWork
      *
      * @var array
      */
-    private $identityMap = array();
+    private $identityMap = [];
 
     /**
      * Map of all identifiers of managed entities.
@@ -67,7 +67,7 @@ class UnitOfWork
      *
      * @var array
      */
-    private $entityIdentifiers = array();
+    private $entityIdentifiers = [];
 
     /**
      * @param ObjectManager   $manager
@@ -258,7 +258,7 @@ class UnitOfWork
         /** @var ClassMetadata $classMetadata */
         $classMetadata = $this->manager->getClassMetadata($className);
 
-        $id = array();
+        $id = [];
         foreach ($classMetadata->getIdentifierFieldNames() as $idField) {
             $id[$idField] = $data[$idField];
         }

--- a/tests/Functional/EntityRepositoryTest.php
+++ b/tests/Functional/EntityRepositoryTest.php
@@ -37,7 +37,7 @@ class EntityRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->connection = \Mockery::mock('RAPL\RAPL\Connection\ConnectionInterface');
 
         $configuration = new Configuration();
-        $paths         = array(__DIR__.'/../Fixtures/config');
+        $paths         = [__DIR__.'/../Fixtures/config'];
         $driver        = new YamlDriver($paths, '.rapl.yml');
         $configuration->setMetadataDriver($driver);
 
@@ -130,7 +130,7 @@ class EntityRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->mockHttpRequestAndResponse('books', 200, $json);
 
         /** @var Book $actual */
-        $actual = $this->repository->findOneBy(array());
+        $actual = $this->repository->findOneBy([]);
 
         $this->assertInstanceOf('RAPL\Tests\Fixtures\Entities\Book', $actual);
         $this->assertSame('Winnie the Pooh', $actual->getTitle());
@@ -145,7 +145,7 @@ class EntityRepositoryTest extends \PHPUnit_Framework_TestCase
     private function mockHttpRequestAndResponse($uri, $responseCode = 200, $responseData = '')
     {
         $request  = new Request('GET', $uri);
-        $response = new Response($responseCode, array(), $responseData);
+        $response = new Response($responseCode, [], $responseData);
 
         $this->connection->shouldReceive('createRequest')->once()->with('GET', $uri)->andReturn($request);
 

--- a/tests/Unit/Connection/ConnectionTest.php
+++ b/tests/Unit/Connection/ConnectionTest.php
@@ -37,7 +37,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
     public function testAddSubscriber()
     {
         $subscriber = \Mockery::mock('Symfony\Component\EventDispatcher\EventSubscriberInterface');
-        $subscriber->shouldReceive('getSubscribedEvents')->once()->andReturn(array());
+        $subscriber->shouldReceive('getSubscribedEvents')->once()->andReturn([]);
 
         $this->connection->addSubscriber($subscriber);
     }

--- a/tests/Unit/EntityManagerTest.php
+++ b/tests/Unit/EntityManagerTest.php
@@ -163,7 +163,7 @@ class EntityManagerTest extends \PHPUnit_Framework_TestCase
     {
         $object = new \stdClass();
 
-        $this->unitOfWork->shouldReceive('initializeObject')->withArgs(array($object))->once();
+        $this->unitOfWork->shouldReceive('initializeObject')->withArgs([$object])->once();
 
         $this->entityManager->initializeObject($object);
     }
@@ -172,9 +172,9 @@ class EntityManagerTest extends \PHPUnit_Framework_TestCase
     {
         $object = new \stdClass();
 
-        $this->unitOfWork->shouldReceive('isScheduledForInsert')->withArgs(array($object))->andReturn(false)->once();
-        $this->unitOfWork->shouldReceive('isInIdentityMap')->withArgs(array($object))->andReturn(true)->once();
-        $this->unitOfWork->shouldReceive('isScheduledForDelete')->withArgs(array($object))->andReturn(false)->once();
+        $this->unitOfWork->shouldReceive('isScheduledForInsert')->withArgs([$object])->andReturn(false)->once();
+        $this->unitOfWork->shouldReceive('isInIdentityMap')->withArgs([$object])->andReturn(true)->once();
+        $this->unitOfWork->shouldReceive('isScheduledForDelete')->withArgs([$object])->andReturn(false)->once();
 
         $this->assertTrue($this->entityManager->contains($object));
     }

--- a/tests/Unit/EntityRepositoryTest.php
+++ b/tests/Unit/EntityRepositoryTest.php
@@ -35,27 +35,27 @@ class EntityRepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $object = new Book();
 
-        $this->entityPersister->shouldReceive('loadById')->once()->with(array('id' => 3))->andReturn($object);
-        $this->classMetadata->shouldReceive('getIdentifierFieldNames')->once()->andReturn(array('id'));
+        $this->entityPersister->shouldReceive('loadById')->once()->with(['id' => 3])->andReturn($object);
+        $this->classMetadata->shouldReceive('getIdentifierFieldNames')->once()->andReturn(['id']);
 
         $this->assertSame($object, $this->entityRepository->find(3));
     }
 
     public function testFindAll()
     {
-        $result = array(new Book());
+        $result = [new Book()];
 
-        $this->entityPersister->shouldReceive('loadAll')->once()->with(array(), null, null, null)->andReturn($result);
+        $this->entityPersister->shouldReceive('loadAll')->once()->with([], null, null, null)->andReturn($result);
 
         $this->assertSame($result, $this->entityRepository->findAll());
     }
 
     public function testFindBy()
     {
-        $result = array(new Book());
+        $result = [new Book()];
 
-        $criteria = array('id' => 3);
-        $orderBy  = array('name' => 'asc');
+        $criteria = ['id' => 3];
+        $orderBy  = ['name' => 'asc'];
         $limit    = 10;
         $offset   = 20;
 
@@ -72,9 +72,9 @@ class EntityRepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $object = new Book();
 
-        $result = array($object);
+        $result = [$object];
 
-        $criteria = array('id' => 3);
+        $criteria = ['id' => 3];
 
         $this->entityPersister->shouldReceive('loadAll')->once()->with($criteria, null, null, null)->andReturn($result);
 

--- a/tests/Unit/Mapping/ClassMetadataTest.php
+++ b/tests/Unit/Mapping/ClassMetadataTest.php
@@ -20,8 +20,8 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $this->classMetadata = new ClassMetadata(self::CLASS_NAME);
 
-        $this->classMetadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
-        $this->classMetadata->mapField(array('fieldName' => 'title', 'serializedName' => 'book_title'));
+        $this->classMetadata->mapField(['fieldName' => 'id', 'type' => 'integer', 'id' => true]);
+        $this->classMetadata->mapField(['fieldName' => 'title', 'serializedName' => 'book_title']);
 
         $reflService = new RuntimeReflectionService();
 
@@ -70,7 +70,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFieldNamesReturnsMappedFieldNames()
     {
-        $this->assertSame(array('id', 'title'), $this->classMetadata->getFieldNames());
+        $this->assertSame(['id', 'title'], $this->classMetadata->getFieldNames());
     }
 
     public function testGetFieldNameReturnsFieldNameForSerializedName()
@@ -81,7 +81,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     public function testGetFieldMappingReturnsFieldMapping()
     {
         $this->assertSame(
-            array('fieldName' => 'title', 'serializedName' => 'book_title', 'type' => 'string'),
+            ['fieldName' => 'title', 'serializedName' => 'book_title', 'type' => 'string'],
             $this->classMetadata->getFieldMapping('title')
         );
     }
@@ -95,8 +95,8 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
     public function testGetIdentifierFieldNames()
     {
-        $this->assertEquals(array('id'), $this->classMetadata->getIdentifierFieldNames());
-        $this->assertEquals(array('id'), $this->classMetadata->getIdentifier());
+        $this->assertEquals(['id'], $this->classMetadata->getIdentifierFieldNames());
+        $this->assertEquals(['id'], $this->classMetadata->getIdentifier());
     }
 
     public function testGetTypeOfField()
@@ -115,11 +115,11 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     public function testIsAssociationInverseSide()
     {
         $this->classMetadata->mapField(
-            array(
+            [
                 'fieldName'    => 'foo',
                 'association'  => ClassMetadata::EMBED_ONE,
                 'isOwningSide' => false,
-            )
+            ]
         );
 
         $this->assertTrue($this->classMetadata->isAssociationInverseSide('foo'));
@@ -128,11 +128,11 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     public function testGetAssociationMappedByTargetField()
     {
         $this->classMetadata->mapField(
-            array(
+            [
                 'fieldName'   => 'foo',
                 'association' => ClassMetadata::EMBED_ONE,
                 'mappedBy'    => 'bar',
-            )
+            ]
         );
 
         $this->assertSame('bar', $this->classMetadata->getAssociationMappedByTargetField('foo'));
@@ -144,14 +144,14 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $object->setId(123);
 
         $actual = $this->classMetadata->getIdentifierValues($object);
-        $this->assertSame(array('id' => 123), $actual);
+        $this->assertSame(['id' => 123], $actual);
     }
 
     public function testMapFieldValidatesAndCompletesFieldMapping()
     {
-        $mapping = array(
+        $mapping = [
             'fieldName' => 'test',
-        );
+        ];
 
         $this->classMetadata->mapField($mapping);
 
@@ -164,17 +164,17 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('RAPL\RAPL\Mapping\MappingException');
 
-        $this->classMetadata->mapField(array());
+        $this->classMetadata->mapField([]);
     }
 
     public function testEmbedOne()
     {
         $fieldName = 'author';
 
-        $mapping = array(
+        $mapping = [
             'fieldName'    => $fieldName,
             'targetEntity' => 'RAPL\Tests\Fixtures\Entities\Author',
-        );
+        ];
 
         $this->classMetadata->mapEmbedOne($mapping);
 
@@ -183,7 +183,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->classMetadata->hasAssociation($fieldName));
         $this->assertTrue($this->classMetadata->isSingleValuedAssociation($fieldName));
         $this->assertFalse($this->classMetadata->isCollectionValuedAssociation($fieldName));
-        $this->assertSame(array('author'), $this->classMetadata->getAssociationNames());
+        $this->assertSame(['author'], $this->classMetadata->getAssociationNames());
         $this->assertSame(
             'RAPL\Tests\Fixtures\Entities\Author',
             $this->classMetadata->getAssociationTargetClass($fieldName)
@@ -194,14 +194,14 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('RAPL\RAPL\Mapping\MappingException');
 
-        $this->classMetadata->mapEmbedOne(array('fieldName' => 'author'));
+        $this->classMetadata->mapEmbedOne(['fieldName' => 'author']);
     }
 
     public function testMapEmbedOneWithoutFieldNameThrowsException()
     {
         $this->setExpectedException('RAPL\RAPL\Mapping\MappingException');
 
-        $this->classMetadata->mapEmbedOne(array('targetEntity' => 'RAPL\Tests\Fixtures\Entities\Author'));
+        $this->classMetadata->mapEmbedOne(['targetEntity' => 'RAPL\Tests\Fixtures\Entities\Author']);
     }
 
     public function testNewInstance()
@@ -223,8 +223,8 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($this->classMetadata->getRoute('resource'));
 
-        $resourceRoute   = new Route('books/{id}', array('results', 0));
-        $collectionRoute = new Route('books', array('results'));
+        $resourceRoute   = new Route('books/{id}', ['results', 0]);
+        $collectionRoute = new Route('books', ['results']);
 
         $this->classMetadata->setRoute('resource', $resourceRoute);
         $this->classMetadata->setRoute('collection', $collectionRoute);

--- a/tests/Unit/Mapping/Driver/YamlDriverTest.php
+++ b/tests/Unit/Mapping/Driver/YamlDriverTest.php
@@ -20,7 +20,7 @@ class YamlDriverTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $paths               = array(__DIR__.'/../../../Fixtures/config/');
+        $paths               = [__DIR__.'/../../../Fixtures/config/'];
         $this->mappingDriver = new YamlDriver($paths);
 
         $this->classMetadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
@@ -43,45 +43,45 @@ class YamlDriverTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('mapField')
             ->once()
             ->with(
-                array(
+                [
                     'fieldName'      => 'id',
                     'type'           => 'integer',
                     'serializedName' => null,
                     'id'             => true,
-                )
+                ]
             );
 
         $this->classMetadata
             ->shouldReceive('mapField')
             ->once()
             ->with(
-                array(
+                [
                     'fieldName'      => 'title',
                     'type'           => 'string',
                     'serializedName' => null,
-                )
+                ]
             );
 
         $this->classMetadata
             ->shouldReceive('mapField')
             ->once()
             ->with(
-                array(
+                [
                     'fieldName'      => 'isbn',
                     'type'           => null,
                     'serializedName' => null,
-                )
+                ]
             );
 
         $this->classMetadata
             ->shouldReceive('mapEmbedOne')
             ->once()
             ->with(
-                array(
+                [
                     'targetEntity'   => 'RAPL\Tests\Fixtures\Entities\Author',
                     'fieldName'      => 'author',
                     'serializedName' => null,
-                )
+                ]
             );
 
         $this->mappingDriver->loadMetadataForClass(self::CLASS_NAME, $this->classMetadata);

--- a/tests/Unit/Mapping/RouteTest.php
+++ b/tests/Unit/Mapping/RouteTest.php
@@ -9,7 +9,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     public function testRoute()
     {
         $pattern   = 'foo/bar/{id}';
-        $envelopes = array('foo', 'bar');
+        $envelopes = ['foo', 'bar'];
 
         $route = new Route($pattern, false, $envelopes);
 

--- a/tests/Unit/Routing/QueryTest.php
+++ b/tests/Unit/Routing/QueryTest.php
@@ -8,8 +8,8 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 {
     public function testQuery()
     {
-        $conditions = array('foo' => 'bar');
-        $orderBy    = array('foo' => 'desc');
+        $conditions = ['foo' => 'bar'];
+        $orderBy    = ['foo' => 'desc'];
         $limit      = 5;
         $offset     = 0;
 
@@ -23,11 +23,11 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 
     public function testRemoveCondition()
     {
-        $conditions = array('foo' => 'bar', 'bar' => 'barbaz');
+        $conditions = ['foo' => 'bar', 'bar' => 'barbaz'];
 
         $query = new Query($conditions);
 
         $query->removeCondition('foo');
-        $this->assertSame(array('bar' => 'barbaz'), $query->getConditions());
+        $this->assertSame(['bar' => 'barbaz'], $query->getConditions());
     }
 }

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -26,7 +26,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->classMetadata->shouldReceive('hasRoute')->with('resource')->andReturn(true);
         $this->classMetadata->shouldReceive('hasRoute')->with('collection')->andReturn(true);
 
-        $this->classMetadata->shouldReceive('getIdentifierFieldNames')->andReturn(array('id'));
+        $this->classMetadata->shouldReceive('getIdentifierFieldNames')->andReturn(['id']);
 
         $this->classMetadata->shouldReceive('getRoute')->with('resource')->andReturn(new Route('books/{id}'));
         $this->classMetadata->shouldReceive('getRoute')->with('collection')->andReturn(new Route('books'));
@@ -42,14 +42,14 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateWithIdentifierAsConditionReturnsResourceUri()
     {
-        $this->assertSame('books/3', $this->router->generate($this->classMetadata, array('id' => 3)));
+        $this->assertSame('books/3', $this->router->generate($this->classMetadata, ['id' => 3]));
     }
 
     public function testGenerateWithNonIdentifierConditionsReturnsCollectionUriWithQueryString()
     {
         $this->assertSame(
             'books?serialized_title=Foo',
-            $this->router->generate($this->classMetadata, array('title' => 'Foo'))
+            $this->router->generate($this->classMetadata, ['title' => 'Foo'])
         );
     }
 
@@ -66,6 +66,6 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             'A collection route is not configured for class Foo\Bar.'
         );
 
-        $this->router->generate($classMetadata, array());
+        $this->router->generate($classMetadata, []);
     }
 }

--- a/tests/Unit/Serializer/SerializerTest.php
+++ b/tests/Unit/Serializer/SerializerTest.php
@@ -45,7 +45,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
      * @param string        $fieldName
      * @param array         $mapping
      */
-    private function addFieldMappingTo(MockInterface $classMetadataMock, $fieldName, array $mapping = array())
+    private function addFieldMappingTo(MockInterface $classMetadataMock, $fieldName, array $mapping = [])
     {
         if (!isset($mapping['serializedName'])) {
             $mapping['serializedName'] = $fieldName;
@@ -79,14 +79,14 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->addFieldMappingTo(
             $this->classMetadata,
             'stringData',
-            array(
+            [
                 'serializedName' => 'string',
                 'type'           => 'string',
-            )
+            ]
         );
 
-        $returnedEntity  = $this->mockReturnEntity('Foo\Bar', array('stringData' => 'Foo Bar'));
-        $returnedEntity2 = $this->mockReturnEntity('Foo\Bar', array('stringData' => 'Bar Baz'));
+        $returnedEntity  = $this->mockReturnEntity('Foo\Bar', ['stringData' => 'Foo Bar']);
+        $returnedEntity2 = $this->mockReturnEntity('Foo\Bar', ['stringData' => 'Bar Baz']);
 
         $json = '[
             {
@@ -109,10 +109,10 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->addFieldMappingTo(
             $this->classMetadata,
             'stringData',
-            array('serializedName' => 'string', 'type' => 'string')
+            ['serializedName' => 'string', 'type' => 'string']
         );
 
-        $returnedEntity = $this->mockReturnEntity('Foo\Bar', array('stringData' => 'Foo Bar'));
+        $returnedEntity = $this->mockReturnEntity('Foo\Bar', ['stringData' => 'Foo Bar']);
 
         $json = '{
             "string": "Foo Bar"
@@ -129,19 +129,19 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->addFieldMappingTo(
             $this->classMetadata,
             'stringData',
-            array(
+            [
                 'serializedName' => 'string',
                 'type'           => 'string',
-            )
+            ]
         );
 
-        $returnedEntity = $this->mockReturnEntity('Foo\Bar', array('stringData' => 'Foo Bar'));
+        $returnedEntity = $this->mockReturnEntity('Foo\Bar', ['stringData' => 'Foo Bar']);
 
         $json = '{"results": [{
             "string": "Foo Bar"
         }]}';
 
-        $entities = $this->serializer->deserialize($json, true, array('results'));
+        $entities = $this->serializer->deserialize($json, true, ['results']);
 
         $this->assertSame(1, count($entities));
         $this->assertSame($returnedEntity, $entities[0]);
@@ -155,7 +155,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
             "foo": "bar"
         }]}';
 
-        $result = $this->serializer->deserialize($json, true, array('envelope'));
+        $result = $this->serializer->deserialize($json, true, ['envelope']);
 
         $this->assertEmpty($result);
     }
@@ -166,13 +166,13 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->addFieldMappingTo(
             $this->classMetadata,
             'embedded',
-            array(
+            [
                 'serializedName' => 'assoc',
                 'embedded'       => true,
                 'type'           => 'one',
                 'association'    => ClassMetadata::EMBED_ONE,
                 'targetEntity'   => 'Foo\BarBaz',
-            )
+            ]
         );
 
         $subClassMetadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
@@ -181,8 +181,8 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
         $this->addFieldMappingTo($subClassMetadata, 'foo');
 
-        $subEntity  = $this->mockReturnEntity('Foo\BarBaz', array('foo' => 'bar'));
-        $mainEntity = $this->mockReturnEntity('Foo\Bar', array('string' => 'foo', 'embedded' => $subEntity));
+        $subEntity  = $this->mockReturnEntity('Foo\BarBaz', ['foo' => 'bar']);
+        $mainEntity = $this->mockReturnEntity('Foo\Bar', ['string' => 'foo', 'embedded' => $subEntity]);
 
         $this->classMetadataFactory->shouldReceive('getMetadataFor')->andReturn($subClassMetadata);
 
@@ -205,13 +205,13 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->addFieldMappingTo(
             $this->classMetadata,
             'embedded',
-            array(
+            [
                 'serializedName' => 'assoc',
                 'embedded'       => true,
                 'type'           => 'one',
                 'association'    => ClassMetadata::EMBED_ONE,
                 'targetEntity'   => 'Foo\BarBaz',
-            )
+            ]
         );
 
         $subClassMetadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
@@ -220,7 +220,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
         $this->addFieldMappingTo($subClassMetadata, 'foo');
 
-        $mainEntity = $this->mockReturnEntity('Foo\Bar', array('string' => 'foo', 'embedded' => null));
+        $mainEntity = $this->mockReturnEntity('Foo\Bar', ['string' => 'foo', 'embedded' => null]);
 
         $this->classMetadataFactory->shouldReceive('getMetadataFor')->andReturn($subClassMetadata);
 

--- a/tests/Unit/UnitOfWorkTest.php
+++ b/tests/Unit/UnitOfWorkTest.php
@@ -29,7 +29,7 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
     {
         $router              = \Mockery::mock('RAPL\RAPL\Routing\RouterInterface');
         $this->classMetadata = \Mockery::mock('RAPL\RAPL\Mapping\ClassMetadata');
-        $this->classMetadata->shouldReceive('getIdentifierFieldNames')->andReturn(array('id'));
+        $this->classMetadata->shouldReceive('getIdentifierFieldNames')->andReturn(['id']);
         $this->classMetadata->shouldReceive('newInstance')->andReturn(new Book());
         $this->classMetadata->shouldReceive('hasField')->with('id')->andReturn(true);
         $this->classMetadata->shouldReceive('hasField')->with('title')->andReturn(true);
@@ -74,7 +74,7 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
 
     public function testIsInIdentityMap()
     {
-        $entityA = $this->unitOfWork->createEntity(self::CLASS_NAME, array('id' => 123, 'title' => 'Foo'));
+        $entityA = $this->unitOfWork->createEntity(self::CLASS_NAME, ['id' => 123, 'title' => 'Foo']);
         $entityB = new Book();
 
         $this->assertTrue($this->unitOfWork->isInIdentityMap($entityA));
@@ -83,14 +83,14 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
 
     public function testAddToIdentityMapReturnsFalseIfEntityIsAlreadyInIdentityMap()
     {
-        $entity = $this->unitOfWork->createEntity(self::CLASS_NAME, array('id' => 123, 'title' => 'Foo'));
+        $entity = $this->unitOfWork->createEntity(self::CLASS_NAME, ['id' => 123, 'title' => 'Foo']);
 
         $this->assertFalse($this->unitOfWork->addToIdentityMap($entity));
     }
 
     public function testRemoveFromIdentityMapRemovesEntityFromIdentityMap()
     {
-        $entity = $this->unitOfWork->createEntity(self::CLASS_NAME, array('id' => 123, 'title' => 'Foo'));
+        $entity = $this->unitOfWork->createEntity(self::CLASS_NAME, ['id' => 123, 'title' => 'Foo']);
 
         $this->assertTrue($this->unitOfWork->removeFromIdentityMap($entity));
         $this->assertFalse($this->unitOfWork->isInIdentityMap($entity));
@@ -99,10 +99,10 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateEntity()
     {
-        $data = array(
+        $data = [
             'id'    => 123,
             'title' => 'Foo Bar',
-        );
+        ];
 
         /** @var Book $actual */
         $actual = $this->unitOfWork->createEntity(self::CLASS_NAME, $data);
@@ -112,10 +112,10 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
 
     public function testCallingCreateEntityTwiceReturnsSameInstance()
     {
-        $data = array(
+        $data = [
             'id'    => 123,
             'title' => 'Foo Bar',
-        );
+        ];
 
         $this->assertSame(
             $this->unitOfWork->createEntity(self::CLASS_NAME, $data),


### PR DESCRIPTION
PHP 5.3 is end of life since August 2014. By dropping support we can start using new features such as the short array syntax, and upgrade Guzzle to the latest version.